### PR TITLE
Convert `preprocess.ipynb` into a set of preprocessing scripts

### DIFF
--- a/_ridership_utils/requirements.txt
+++ b/_ridership_utils/requirements.txt
@@ -10,6 +10,7 @@ mapclassify (>=2.8.0,<3)
 movingpandas==0.22.4
 numba (>=0.62.1, <0.63.0)
 omegaconf==2.3.0 # better yaml configuration
+openpyxl>=3.1.0
 polars==1.22.0
 quarto==0.1.0
 quarto-cli==1.6.40

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -3,6 +3,22 @@
 clean_transit_data:
 	python clean_bart.py
 	python clean_big_blue_bus.py
+	python clean_caltrain.py
+	python clean_culver_citybus.py
+	python clean_fresno_area_express.py
+	python clean_gold_coast_transit.py
+	python clean_golden_gate_park_shuttle.py
+	python clean_golden_gate_transit.py
+	python clean_long_beach_transit.py
+	python clean_octa.py
+	python clean_omnitrans.py
+	# python clean_riverside.py # two part, upload transactions, save as parquet, then aggregate to stop
+	python clean_sacrt.py
+	python clean_samtrans.py
+	python clean_santa_cruz_metro.py
+	python clean_sbmtd.py
+	python clean_sdmts.py
+	python clean_sunline.py
 
 upload_transit_data:
 	python upload_raw_excel_to_gcs.py

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,2 +1,7 @@
+# almost makes sense for these to go first, as we'll always be visually inspecting first
+# pd.read_excel() engines aren't working with GCS
+clean_transit_data:
+	python clean_bart.py
+
 upload_transit_data:
 	python upload_raw_excel_to_gcs.py

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -6,3 +6,7 @@ clean_transit_data:
 
 upload_transit_data:
 	python upload_raw_excel_to_gcs.py
+
+ingest_and_upload_raw_data:
+	make clean_transit_data
+	make upload_transit_data	

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -2,6 +2,7 @@
 # pd.read_excel() engines aren't working with GCS
 clean_transit_data:
 	python clean_bart.py
+	python clean_big_blue_bus.py
 
 upload_transit_data:
 	python upload_raw_excel_to_gcs.py

--- a/scripts/clean_bart.py
+++ b/scripts/clean_bart.py
@@ -5,9 +5,7 @@ Join raw data and station crosswalk tables to get full station name.
 """
 import gcsfs
 import pandas as pd
-from shared_vars import RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
-
-LOCAL_FOLDER = "../transit_agency_ridership_raw_datasets2/"
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
 
 def ingest_bart_entries_and_exits(
     agency_name: str = "bart",

--- a/scripts/clean_bart.py
+++ b/scripts/clean_bart.py
@@ -1,0 +1,115 @@
+"""
+BART
+Reformat data from wide to long format.
+Join raw data and station crosswalk tables to get full station name.
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+LOCAL_FOLDER = "../transit_agency_ridership_raw_datasets2/"
+
+def ingest_bart_entries_and_exits(
+    agency_name: str = "bart",
+    sheet_name: str = "Daily Raw Data"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    raw_bart = pd.read_excel(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}", sheet_name=sheet_name, header=[0,1],
+		engine="openpyxl"
+    )
+	
+    # get level 1 and level 2 headers
+    top_headers = raw_bart.columns.get_level_values(0)
+    bottom_headers  = raw_bart.columns.get_level_values(1)
+
+    # identify metadata columns and ridership columns (entries/exits)
+    meta_cols = [c for c, top in zip(raw_bart.columns, top_headers) if "Unnamed" in str(top)]
+    ridership_cols = [c for c, top in zip(raw_bart.columns, top_headers) if ("Exits"  in str(top)) or ("Entries" in str(top))]
+
+    # melt ridership columns
+    t_df_ridership = raw_bart.melt(
+        id_vars=meta_cols, value_vars=ridership_cols, value_name="ridership"
+    ).rename(
+        columns={
+            "variable_0": "type",
+            "variable_1": "Station"
+        }
+    )
+
+    # pivot table
+    t_df_ridership_pivot = t_df_ridership.pivot_table(
+        index=meta_cols+["Station"],
+        columns="type",
+        values="ridership",
+        aggfunc="sum"
+    ).reset_index()
+    
+    t_df_ridership_pivot.columns = [
+		bottom_headers[i] 
+		if i < len(meta_cols) else t_df_ridership_pivot.columns[i] 
+        for i in range(len(t_df_ridership_pivot.columns))
+	]
+
+    return t_df_ridership_pivot
+
+
+def ingest_bart_station_crosswalk(
+    agency_name: str = "bart",
+    sheet_name: str = "Station Crosswalk"
+) -> pd.DataFrame:
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_bart_station = pd.read_excel(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}", 
+		sheet_name=sheet_name, 
+		engine="openpyxl"
+    )
+    raw_bart_station.columns = ["Station Code", "Station Name"]
+
+    return raw_bart_station
+
+
+def merge_bart_entries_exits_station(
+    entries_df: pd.DataFrame,
+    station_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Join raw data and station crosswalk tables to get full station name.
+    """
+    # add station name
+    raw_bart_export = pd.merge(
+        entries_df, 
+        station_df, 
+        how="left", 
+        left_on="Station", 
+        right_on="Station Code"
+    ).drop(
+		columns="Station Code"
+	).astype({"Station": "str"})
+    
+    # add date range, columns needed, coerce dtypes
+    raw_bart_export = raw_bart_export.assign(
+        start_date = pd.to_datetime(raw_bart_export.Date),
+        end_date = pd.to_datetime(raw_bart_export.Date),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    )
+
+    return raw_bart_export
+    
+if __name__ == "__main__":
+    
+    agency_name = "bart"   
+	
+    t_df_ridership_pivot = ingest_bart_entries_and_exits(agency_name)
+    raw_bart_station = ingest_bart_station_crosswalk(agency_name)
+    
+    raw_bart_export = merge_bart_entries_exits_station(t_df_ridership_pivot, raw_bart_station)
+    raw_bart_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_big_blue_bus.py
+++ b/scripts/clean_big_blue_bus.py
@@ -1,0 +1,40 @@
+"""
+Big Blue Bus
+Add start and end date of service period/aggregation period.
+Note: Each stop id can have more than 1 record.
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_big_blue_bus(
+    agency_name: str = "big_blue_bus"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    raw_big_blue_bus = pd.read_excel(
+		f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl"
+	)
+    raw_big_blue_bus_export = raw_big_blue_bus.groupby(
+        ["SERVICE_PERIOD", "SERVICE_DAY", "ROUTE_NUMBER", "ROUTE_NAME", "DIRECTION_NAME",
+        "STOP_ID", "STOP_NAME", "STOP_LAT", "STOP_LON"], dropna=False
+    )[["AVERAGE_DAILY_BOARDINGS", "AVERAGE_DAILY_ALIGHTINGS"]].sum().reset_index()
+
+    raw_big_blue_bus_export["start_date"] = raw_big_blue_bus_export["SERVICE_PERIOD"]
+    raw_big_blue_bus_export["end_date"] = raw_big_blue_bus_export["SERVICE_PERIOD"] + pd.offsets.MonthEnd(4)
+    raw_big_blue_bus_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    
+    return raw_big_blue_bus_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "big_blue_bus"
+    raw_big_blue_bus_export = ingest_big_blue_bus(agency_name)
+    raw_big_blue_bus_export.to_parquet(
+        f"{RAW_GCS}/{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+	
+    print(f"exported: {agency_name}")

--- a/scripts/clean_big_blue_bus.py
+++ b/scripts/clean_big_blue_bus.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     agency_name = "big_blue_bus"
     raw_big_blue_bus_export = ingest_big_blue_bus(agency_name)
     raw_big_blue_bus_export.to_parquet(
-        f"{RAW_GCS}/{agency_name}/ridership_round1.parquet",
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
         filesystem = gcsfs.GCSFileSystem()
     )
 	

--- a/scripts/clean_caltrain.py
+++ b/scripts/clean_caltrain.py
@@ -1,0 +1,55 @@
+"""
+Caltrain
+Unmerge first column "Month, Year of Date", and rename columns.
+Add start and end date for each period.
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_caltrain(
+    agency_name: str = "caltrain"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_caltrain = pd.read_excel(
+		f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl"
+	).reset_index(drop=True)
+    
+    raw_caltrain["Month, Year of Date"] = raw_caltrain["Month, Year of Date"].ffill()
+    raw_caltrain = pd.melt(
+        raw_caltrain, 
+        id_vars=["Month, Year of Date", "Origin Station", "Caltrain Ridership"]
+    ).rename(columns={
+        "variable": "Date Type",
+        "value": "Average Ridership",
+        "Month, Year of Date": "Month"}
+    )
+
+    raw_caltrain["Date Type"] = raw_caltrain["Date Type"].replace({
+            "Average Weekday Ridership": "Weekday",
+            "Average Saturday Ridership": "Saturday",
+            "Average Sunday Ridership": "Sunday",
+            "Average Holiday Ridership": "Holiday"
+    })
+
+    raw_caltrain["start_date"] = pd.to_datetime(raw_caltrain["Month"], format="%B %Y")
+    raw_caltrain["end_date"] = raw_caltrain["start_date"] + pd.offsets.MonthEnd(1)
+    raw_caltrain["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+
+    return raw_caltrain
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "caltrain"
+    
+    raw_caltrain = ingest_caltrain(agency_name)
+    raw_caltrain.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+	
+    print(f"exported: {agency_name}")

--- a/scripts/clean_culver_citybus.py
+++ b/scripts/clean_culver_citybus.py
@@ -1,0 +1,56 @@
+"""
+Culver CityBus
+
+1. Skip first row (empty) in csv
+2. Aggregate numbers of each time period of day to get daily level ridership.
+Note: Stop sequence can be different for one stop.
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_culver_citybus(
+    agency_name: str = "culver_citybus"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    raw_culver_city = pd.read_csv(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}", skiprows=[1]
+    )
+
+    raw_culver_city_export = (
+        raw_culver_city.groupby(
+            ['Day Of Week', 'Route', 'Direction', 'Stop ID', 'Stop Name'], dropna=False
+        )[['Time Period AVG On', 'Time Period AVG Off']].sum() 
+        .reset_index()
+        .rename(
+            columns={'Time Period AVG On': 'AVG On', 'Time Period AVG Off': 'AVG Off'}
+        )
+    )
+    
+    raw_culver_city_export['start_date'] = pd.to_datetime('2025-07-14')
+    raw_culver_city_export['end_date'] = pd.to_datetime('2025-08-25')
+    
+    raw_culver_city_export["route_id"] = raw_culver_city_export["Route"].str.extract(r"^\s*([A-Za-z0-9 ]+?)\s*-\s*")
+    
+    day_type_map = {
+        "1-Weekday": "Weekday",
+        "2-Saturday": "Saturday",
+        "3-Sunday": "Sunday"
+    }
+    raw_culver_city_export["day_type"] = raw_culver_city_export["Day Of Week"].map(day_type_map)
+    raw_culver_city_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+
+    return raw_culver_city_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "culver_citybus"
+    
+    raw_culver_city_export = ingest_culver_citybus(agency_name)
+    raw_culver_city_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )

--- a/scripts/clean_fresno_area_express.py
+++ b/scripts/clean_fresno_area_express.py
@@ -1,0 +1,45 @@
+"""
+Fresno Area Express (City of Fresno) 
+  script is called clean_fresno_area_express (change yaml), 
+  but yaml change to Fresno Area Express would be more descriptive and follow how 
+  other folders describe transit agencies, not organizations (could be city).
+  the exported Excel was named Fresno Area Express, indicating this is the folder to use.
+Add day type, start and end date column to fit in staging table schema.
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_fresno_area_express(
+    agency_name: str = "fresno_area_express"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    raw_fresno = pd.read_excel(f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl")
+
+    raw_fresno_export = raw_fresno.groupby(
+        by=["Date", "StopID", "StopLabel"], dropna=False
+    )[["ProjectedBoarding", "ProjectedAlighting"]].sum().reset_index()
+    
+    raw_fresno_export["start_date"] = pd.to_datetime(raw_fresno_export["Date"])
+    raw_fresno_export["end_date"] = pd.to_datetime(raw_fresno_export["Date"])
+    raw_fresno_export["day_type"] = raw_fresno_export["Date"].apply(time_utils.get_day_type)
+    raw_fresno_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    
+    return raw_fresno_export
+
+	
+if __name__ == "__main__":
+   
+    agency_name = "fresno_area_express"
+  
+    raw_fresno_export = ingest_fresno_area_express(agency_name)
+    raw_fresno_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+    
+    print(f"exported: {agency_name}")

--- a/scripts/clean_gold_coast_transit.py
+++ b/scripts/clean_gold_coast_transit.py
@@ -1,0 +1,53 @@
+"""
+Gold Coast Transit
+
+1. Import one sheet (May 2025 data) for now, which contains most comprehensive columns/info.
+2. Add headers/column names.
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_gold_coast_transit(
+    agency_name: str = "gold_coast_transit",
+    sheet_name: str = "May_2025_Stop_Ridership"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+	# specify headers (inferred from other sheets from the same excel)
+    headers = [
+        'day_of_week', 'route', 'direction', 'stop_id', 'unknown', 'stop_name', 'total_on', 'total_off', 
+        'total_activity', 'cumulative_load', 'lat', 'lon'
+    ]
+    # .xls needs a different engine
+    raw_gct = pd.read_excel(
+	    f"{LOCAL_FOLDER}{agency_name}/{filename}", 
+        sheet_name=sheet_name, header=None, names=headers,
+        engine="xlrd", 
+	).reset_index(drop=True)
+
+    raw_gct_export = raw_gct.assign(
+        start_date = pd.to_datetime('2025-05-01'),
+        end_date = pd.to_datetime('2025-05-31'),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    ).astype({
+        "route": "str", # this gave error with parquet export because some looked like int
+        "unknown": "int"# this might be stop_sequence
+    })
+
+    return raw_gct_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "gold_coast_transit"
+    
+    raw_gct_export = ingest_gold_coast_transit(agency_name)
+    raw_gct_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_gold_coast_transit.py
+++ b/scripts/clean_gold_coast_transit.py
@@ -34,7 +34,7 @@ def ingest_gold_coast_transit(
         schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
     ).astype({
         "route": "str", # this gave error with parquet export because some looked like int
-        "unknown": "int"# this might be stop_sequence
+        "unknown": "int" # this might be stop_sequence
     })
 
     return raw_gct_export

--- a/scripts/clean_golden_gate_park_shuttle.py
+++ b/scripts/clean_golden_gate_park_shuttle.py
@@ -1,0 +1,58 @@
+"""
+Golden Gate Park Shuttle
+
+1. Reshape the data from a wide format, where each stop is a separate column, into a long 
+format where each row represents the ridership for a specific stop on a specific day.
+2. Filter out Stop = "Total"
+"""
+import gcsfs
+import pandas as pd
+import re
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_golden_gate_park_shuttle(
+    agency_name: str = "golden_gate_park_shuttle",
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_ggp = pd.read_excel(
+	    f"{LOCAL_FOLDER}{agency_name}/{filename}", 
+        header=None, engine="openpyxl", 
+	)
+    
+    # extract first four column names from the second row (index=1)
+    first_four_cols = raw_ggp.iloc[1, 0:4].tolist()
+    
+    # extract stop names from the firs row starting from 5th row
+    stop_names = raw_ggp.iloc[0, 4:].tolist()
+    
+    # extract data starting from 3rd row
+    data_ggp = raw_ggp.iloc[2:, :].copy()
+    data_ggp.columns = first_four_cols + stop_names
+    
+    # convert from wide to long format
+    raw_ggp_export = data_ggp.melt(id_vars=first_four_cols, var_name="Stop", value_name="Ridership")
+    
+    raw_ggp_export = raw_ggp_export.assign(
+        start_date = pd.to_datetime(raw_ggp_export["Date"]),
+        end_date = pd.to_datetime(raw_ggp_export["Date"]),
+        direction = raw_ggp_export["Stop"].str.extract(r"\b([EWSN]\s*B)\b",flags=re.IGNORECASE),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    ).dropna(subset="Date").query('Stop != "Total"')
+    
+    return raw_ggp_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "golden_gate_park_shuttle"
+    
+    raw_ggp_export = ingest_golden_gate_park_shuttle(agency_name)
+    raw_ggp_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_golden_gate_transit.py
+++ b/scripts/clean_golden_gate_transit.py
@@ -1,0 +1,48 @@
+"""
+Golden Gate Transit
+Aggregate to stop level. The raw data has trip-stop grain.
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_golden_gate_transit(
+    agency_name: str = "golden_gate_transit",
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_ggt = pd.read_csv(
+	    f"{LOCAL_FOLDER}{agency_name}/{filename}", encoding="utf-8"
+	)
+    # filter out virtual time points
+    t_df_ggt = raw_ggt[raw_ggt["POINT_ROLE"].isin(["ST", "S"])]
+
+    raw_ggt_export = raw_ggt.groupby(
+        by=["OPERATION_DATE", "ROUTE", "DIRECTION", "STOP_NUMBER", "STOP_NAME"], dropna=False
+    )[["BOARDINGS", "ALIGHTINGS"]].sum().reset_index()
+
+   
+    raw_ggt_export["date"] = pd.to_datetime(raw_ggt_export["OPERATION_DATE"], format="%d-%b-%y")
+    raw_ggt_export["start_date"] = raw_ggt_export["date"]
+    raw_ggt_export["end_date"] = raw_ggt_export["date"]
+    raw_ggt_export["day_type"] = raw_ggt_export["date"].apply(time_utils.get_day_type)
+    raw_ggt_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    
+    return raw_ggt_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "golden_gate_transit"
+    
+    raw_ggt_export = ingest_golden_gate_transit(agency_name)
+    raw_ggt_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_long_beach_transit.py
+++ b/scripts/clean_long_beach_transit.py
@@ -1,0 +1,48 @@
+"""
+Long Beach Transit
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_long_beach_transit(
+    agency_name: str = "long_beach_transit",
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_long_beach = pd.read_excel(
+	    f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl", 
+	)
+
+    raw_long_beach_export = raw_long_beach.groupby(
+        by=['DayType', 'Route', 'Direction', 'StopID', 'StopName'], dropna=False
+    )[['Boardings', 'Alightings']].sum().reset_index()
+    
+    fiscal_year = 2025
+    start_month = 7
+    start_date, end_date = time_utils.get_fiscal_year_range(fiscal_year, start_month)
+
+    raw_long_beach_export = raw_long_beach_export.assign(
+        start_date = pd.to_datetime(start_date),
+        end_date = pd.to_datetime(end_date),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    )
+    
+    return raw_long_beach_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "long_beach_transit"
+    
+    raw_long_beach_export = ingest_long_beach_transit(agency_name)
+    raw_long_beach_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_octa.py
+++ b/scripts/clean_octa.py
@@ -1,0 +1,50 @@
+"""
+OCTA
+
+Aggregate trip-stop/event level (door open/close) ridership to stop level ridership.
+Looks like raw stop name has stop id as prefix. Extract stop id from stop name.
+"""
+import calendar
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_octa(
+    agency_name: str = "octa",
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_octa = pd.read_excel(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}", skiprows=[1], engine="openpyxl", 
+	)
+    
+    raw_octa_export = raw_octa.groupby(
+        by=['Cal Year', 'Month', 'Trans Date', 'Day of Week', 'Route', 'Direction', 'Stop Name'], dropna=False
+    )[['APC Boarding', 'APC Alighting']].sum().reset_index()
+    
+    raw_octa_export["stop_id"] = raw_octa_export["Stop Name"].str.extract(r"^\s*(\d+)\s*[--]\s*")
+    raw_octa_export["route_id"] = raw_octa_export["Route"].str.extract(r"^\s*(\d+)\s*[--]\s*")
+    raw_octa_export["Trans Date"] = pd.to_datetime(raw_octa_export["Trans Date"], errors="coerce")
+    raw_octa_export["day_type"] = raw_octa_export["Trans Date"].apply(time_utils.get_day_type)
+    raw_octa_export["start_date"] = pd.to_datetime(raw_octa_export["Trans Date"])
+    raw_octa_export["end_date"] = pd.to_datetime(raw_octa_export["Trans Date"])
+    raw_octa_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    
+    return raw_octa_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "octa"
+    
+    raw_octa_export = ingest_octa(agency_name)
+    raw_octa_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_omnitrans.py
+++ b/scripts/clean_omnitrans.py
@@ -1,0 +1,65 @@
+"""
+OmniTrans
+
+Average to daily. Raw data is total ridership over each fiscal year.
+Add date according to fiscal year, i.e., first day of the fiscal year.
+Note: For each Stop Name, there can be multiple rows. Need to first sum up for stop name then divided by 365 to get day avg.
+"""
+import calendar
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_omnitrans(
+    agency_name: str = "omnitrans",
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_omni = pd.read_excel(
+	    f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl", 
+	)
+
+    # sum up totals for each stop name
+    raw_omni_export = (
+        raw_omni.groupby(["FiscalYear", "Route", "Stop Name"], dropna=False)
+        [["Total Board", "Total Alight"]]
+        .sum()
+        .reset_index()
+    )
+
+    # avg total ridership of fiscal year
+    raw_omni_export["FiscalYear"] = raw_omni_export["FiscalYear"].astype(int)
+    raw_omni_export["fiscal_year_days"] = raw_omni_export["FiscalYear"].apply(lambda y: 366 if calendar.isleap(y) else 365)
+    raw_omni_export['avg_boardings'] = raw_omni_export['Total Board']/raw_omni_export["fiscal_year_days"]
+    raw_omni_export['avg_alightings'] = raw_omni_export['Total Alight']/raw_omni_export["fiscal_year_days"]
+
+    # specify start month of fiscal year
+    start_month = 7
+    raw_omni_export[["start_date", "end_date"]] = raw_omni_export["FiscalYear"].apply(
+        lambda x: pd.Series(time_utils.get_fiscal_year_range(x, start_month)))
+    
+    raw_omni_export = raw_omni_export.assign(
+        start_date = pd.to_datetime(raw_omni_export.start_date),
+        end_date = pd.to_datetime(raw_omni_export.end_date),
+        day_type = "all",
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    )
+    
+    return raw_omni_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "omnitrans"
+    
+    raw_omni_export = ingest_omnitrans(agency_name)
+    raw_omni_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_riverside_transit.py
+++ b/scripts/clean_riverside_transit.py
@@ -1,0 +1,103 @@
+"""
+Riverside Transit
+Aggregate swipe/transaction level data to stop level ridership
+
+Note: The original raw datasets are transactions data, which are too large to directly upload to Github. 
+The code in this section preprocess the raw data and aggregate to stop level ridership. 
+Raw datasets are not uploaded to Github repo. 
+Lat and lon for each (stop, route, direction) are the max/min of all records for the corresponding combination.
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def aggregate_transactions_to_ridership(transactions_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    extract only valid transaction types (values not in the list are the meta data rows)
+    """
+    ridership_transaction_codes = [
+        "114 - Stored ride card", 
+        "115 - Period pass", "119 - Got fare", 
+        "129 - Special card", "212 - Mobile Ticket Transaction"
+    ]
+    
+    raw_riverside = transactions_df[transactions_df["Transaction Type"].isin(ridership_transaction_codes)]
+
+    raw_riverside["date"] = pd.to_datetime(raw_riverside["Date Time"], errors="coerce").dt.date
+    raw_riverside["date"] = pd.to_datetime(raw_riverside["date"], errors="coerce")
+    
+    raw_riverside_export = (
+        raw_riverside
+        .groupby(["date", "Stop ID", "Route", "Direction"], as_index=False, dropna=False)
+        .agg({
+            "Stop ID": "count",
+            "Longitude": "max",
+            "Latitude": "max"
+        })
+        .rename(columns = {"Stop ID": "ridership"})
+    )
+
+    return raw_riverside_export
+
+
+def filter_transactions(filename: str) -> pd.DataFrame:
+    """
+    Find the index of the first "Search Criteria" row and drop all following rows which are not ridership data.
+    Clean up the filtered transactions to get ridership
+    """
+    t_raw_df = pd.read_csv(filename, header=4)
+            
+    first_col = t_raw_df.columns[0]
+    mask = t_raw_df[first_col].astype(str).str.contains("Search Criteria")
+    if mask.any():
+        cutoff_idx = mask.idxmax()
+        t_raw_df = t_raw_df.loc[:cutoff_idx-1]
+
+    # Coerce dtypes here because we're saving out filtered transactions too.
+    # these dtypes should match what we'll use for transactions -> stop ridership  
+    t_raw_df = t_raw_df.astype({
+        "Route": "int",
+        "Stop ID": "int"
+    })
+
+    return t_raw_df
+
+def ingest_riverside_transit(
+    agency_name: str = "riverside_transit"
+) -> pd.DataFrame:
+    """
+    """
+    list_of_files = list(RAW_DATA_YAML[agency_name])
+
+    filtered_raw_transactions = pd.concat([
+        filter_transactions(f"{LOCAL_FOLDER}{agency_name}/{filename}") 
+        for filename in list_of_files 
+    ], axis=0, ignore_index=True)
+
+    # this needs to be uploaded too
+    filtered_raw_transactions.to_parquet(
+        f"{RAW_GCS}{agency_name}/filtered_transactions_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    raw_riverside_export = aggregate_transactions_to_ridership(filtered_raw_transactions)
+    raw_riverside_export["start_date"] = raw_riverside_export["date"]
+    raw_riverside_export["end_date"] = raw_riverside_export["date"]
+    raw_riverside_export["day_type"] = raw_riverside_export["date"].apply(time_utils.get_day_type)
+    raw_riverside_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+       
+    return raw_riverside_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "riverside_transit"
+    raw_riverside_export = ingest_riverside_transit(agency_name)
+    raw_riverside_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+	
+    print(f"exported: {agency_name}")

--- a/scripts/clean_sacrt.py
+++ b/scripts/clean_sacrt.py
@@ -1,0 +1,122 @@
+"""
+SacRT
+
+1. Join ridership and stops table
+2. Differentiate weekday and weekend ridership
+Note: For the routes that run on weekends, weekends are included in the agg counts. 
+For the routes that don't run on weekends, only weekdays are included in agg conuts. 
+See the indicator columns from Monday to Sunday.
+
+snakecase could be a way to clean columns for all transit agencies, adjust rest of scripts too
+"""
+import gcsfs
+import pandas as pd
+
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_sacrt_ridership(
+    agency_name: str = "sacrt",
+    filename: str = "ridership.txt.csv"
+) -> pd.DataFrame:
+    """
+    """    
+    raw_sacrt_ridership = pd.read_csv(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}", 
+	)
+    raw_sacrt_ridership.columns = raw_sacrt_ridership.columns.str.lower()
+
+    # cast indicator cols to int
+    dow_cols = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+    raw_sacrt_ridership[dow_cols] = raw_sacrt_ridership[dow_cols].apply(pd.to_numeric, errors="coerce").astype("Int64")
+    
+    raw_sacrt_ridership = raw_sacrt_ridership.loc[:, ~raw_sacrt_ridership.columns.str.contains("^unnamed", case=False)]
+    
+    raw_sacrt_ridership_grouped = raw_sacrt_ridership.groupby(
+        ["ridership_start_date", "ridership_end_date", "service_start_time", "service_end_time",
+         "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday", "route_id",
+         "direction_id", "stop_id"], dropna=False
+    )[["average_boardings", "average_alightings"]].sum().reset_index()   
+
+    raw_sacrt_ridership_grouped = raw_sacrt_ridership_grouped.assign(
+        start_date = pd.to_datetime(raw_sacrt_ridership_grouped["ridership_start_date"], 
+                                    format="%Y%m%d").dt.strftime("%Y-%m-%d"),
+		end_date = pd.to_datetime(raw_sacrt_ridership_grouped["ridership_end_date"], 
+                                  format="%Y%m%d").dt.strftime("%Y-%m-%d")
+	)
+    
+    return raw_sacrt_ridership_grouped
+
+    
+def ingest_sacrt_stops(
+    agency_name: str = "sacrt",
+    filename: str = "stops.txt.csv"
+):
+
+    raw_sacrt_stops = pd.read_csv(f"{LOCAL_FOLDER}{agency_name}/{filename}")
+    raw_sacrt_stops = raw_sacrt_stops.dropna(how="all")
+    raw_sacrt_stops['stop_id'] = raw_sacrt_stops['stop_id'].astype("int64")
+    raw_sacrt_stops['stop_code'] = raw_sacrt_stops['stop_code'].astype("int64")
+    raw_sacrt_stops = raw_sacrt_stops.loc[:, ~raw_sacrt_stops.columns.str.contains("^unnamed", case=False)]
+
+    return raw_sacrt_stops
+
+
+def ingest_sacrt_routes(
+    agency_name: str = "sacrt",
+    filename: str = "routes.txt.csv"
+):
+	raw_sacrt_routes = pd.read_csv(f"{LOCAL_FOLDER}{agency_name}/{filename}")
+	raw_sacrt_routes = raw_sacrt_routes.dropna(how="all")
+	raw_sacrt_routes['route_type'] = raw_sacrt_routes['route_type'].astype("int64")
+	
+	return raw_sacrt_routes
+
+    
+def merge_ridership_with_stop_and_routes(
+	ridership_df: pd.DataFrame,
+	stop_df: pd.DataFrame,
+	routes_df: pd.DataFrame
+) -> pd.DataFrame:
+	
+	raw_sacrt_export = pd.merge(
+		ridership_df, 
+		stop_df, 
+		how="left", 
+		on="stop_id"
+	).merge(
+		routes_df, 
+		how="left", 
+		on="route_id"
+	)
+	
+	raw_sacrt_export = raw_sacrt_export.assign(
+		start_date = pd.to_datetime(raw_sacrt_export.start_date),
+		end_date = pd.to_datetime(raw_sacrt_export.end_date),
+		day_type = raw_sacrt_export.apply(
+			lambda x: 
+			"weekday" if x.saturday == 0 and x.sunday == 0
+			else "all", axis=1,
+		),
+		schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+	)
+
+	return raw_sacrt_export
+	
+if __name__ == "__main__":
+   
+    agency_name = "sacrt"
+
+	# define which files match ridership, stops, routes
+    ridership = ingest_sacrt_ridership(agency_name, filename = RAW_DATA_YAML[agency_name][0])
+    stops = ingest_sacrt_stops(agency_name, filename = RAW_DATA_YAML[agency_name][2])
+    routes = ingest_sacrt_routes(agency_name, filename = RAW_DATA_YAML[agency_name][1])
+
+    raw_sacrt_export = merge_ridership_with_stop_and_routes(ridership, stops, routes)
+
+	# only export 1 file, no longer by bus/light_rail
+    raw_sacrt_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_samtrans.py
+++ b/scripts/clean_samtrans.py
@@ -1,0 +1,82 @@
+"""
+SamTrans
+
+1. Combine files into one dataset
+2. Aggregate trip-stop to stop level ridership.
+3. There are cases where stop name strings are diff but they are the same stop because of the dot in the street type, 
+for example, "3rd Ave & Pint St" vs "3rd Ave & Pine St.". 
+Standardize the stop names (keep the version without the dot).
+
+Note: The data is for each trip-stop, including door open and close time. 
+The lat and lon at the same stop can be slightly different across trips. 
+The agg in the preprocessing takes maximum of the lat and lon for each stop across trips, routes and dates.
+
+Potentially, make stop a gdf here and dedupe and keep as geoparquet. 
+Depends how it's used against GTFS in subsequent step.
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_samtrans(
+    agency_name: str = "samtrans"
+) -> pd.DataFrame:
+    """
+    """
+    list_of_files = list(RAW_DATA_YAML[agency_name])
+    raw_samtrans = pd.concat(
+        [pd.read_excel(f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl")
+        for filename in list_of_files], 
+        axis=0, ignore_index=True
+    )
+
+    int_cols_type = ["Run", "Schedule", "Vehicle", "Sequence", "Stop ID", "Ons", "Offs", "Pos Src", "Qual Ind", "Num Sat"]
+    raw_samtrans[int_cols_type] = raw_samtrans[int_cols_type].astype("Int64")
+    raw_samtrans["APC Date"] = pd.to_datetime(raw_samtrans["APC Date"])     
+    raw_samtrans = raw_samtrans[~raw_samtrans["Route"].str.startswith(("Applied filters"), na=False)]
+
+    raw_samtrans_agg = (
+        raw_samtrans
+        .groupby(["Route", "APC Date", "Stop ID", "Stop Name"], dropna=False)
+        .agg({"Ons": "sum", "Offs": "sum"})
+        .reset_index()
+    )
+
+    # could coerce as gdf and dedupe too
+    stop_loc_map = (
+        raw_samtrans
+        .groupby(["Stop ID", "Stop Name"], dropna=False)
+        .agg({"Lat": "max", "Lon": "max"})
+        .reset_index()
+    )
+    
+    raw_samtrans_export = pd.merge(
+        raw_samtrans_agg, 
+        stop_loc_map, 
+        on=["Stop ID", "Stop Name"], 
+        how="left"
+    )
+    
+    raw_samtrans_export = raw_samtrans_export.assign(
+        day_type = pd.to_datetime(raw_samtrans_export["APC Date"]).apply(time_utils.get_day_type),
+        start_date = pd.to_datetime(raw_samtrans["APC Date"]),
+        end_date = pd.to_datetime(raw_samtrans["APC Date"]),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    )
+    
+    return raw_samtrans_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "samtrans"
+  
+    raw_samtrans_export = ingest_samtrans(agency_name)
+    raw_samtrans_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+    
+    print(f"exported: {agency_name}")

--- a/scripts/clean_samtrans.py
+++ b/scripts/clean_samtrans.py
@@ -13,12 +13,45 @@ The agg in the preprocessing takes maximum of the lat and lon for each stop acro
 
 Potentially, make stop a gdf here and dedupe and keep as geoparquet. 
 Depends how it's used against GTFS in subsequent step.
+
+Look at Riverside too and see if both of these can follow a 
+similar workflow to upload parquets in two stages
 """
 import gcsfs
 import pandas as pd
 
+from pathlib import Path
+
 import time_utils
-from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+from shared_vars import LOCAL_FOLDER, AGENCY_GCS, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def export_excel_as_parquet(
+    agency_name: str,
+    list_of_files: list,
+):
+    """
+    SamTrans has a set of Excel files broken down by date ranges.
+    Save each as parquet, check it into GCS with upload script
+    """
+    for filename in list_of_files:
+        df = pd.read_excel(
+            f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl"
+        )
+            
+        int_cols_type = [
+            "Run", "Schedule", "Vehicle", "Sequence", "Stop ID", 
+            "Ons", "Offs", "Pos Src", "Qual Ind", "Num Sat"
+        ]
+        df[int_cols_type] = df[int_cols_type].astype("Int64")
+        df["APC Date"] = pd.to_datetime(df["APC Date"])
+
+        df.to_parquet(
+            f"{AGENCY_GCS}{agency_name}/{Path(filename).stem}.parquet",
+            filesystem = gcsfs.GCSFileSystem()     
+        )
+        print(f"exported {filename} as parquet")
+    
+    return 
 
 def ingest_samtrans(
     agency_name: str = "samtrans"
@@ -26,15 +59,17 @@ def ingest_samtrans(
     """
     """
     list_of_files = list(RAW_DATA_YAML[agency_name])
-    raw_samtrans = pd.concat(
-        [pd.read_excel(f"{LOCAL_FOLDER}{agency_name}/{filename}", engine="openpyxl")
-        for filename in list_of_files], 
-        axis=0, ignore_index=True
-    )
 
-    int_cols_type = ["Run", "Schedule", "Vehicle", "Sequence", "Stop ID", "Ons", "Offs", "Pos Src", "Qual Ind", "Num Sat"]
-    raw_samtrans[int_cols_type] = raw_samtrans[int_cols_type].astype("Int64")
-    raw_samtrans["APC Date"] = pd.to_datetime(raw_samtrans["APC Date"])     
+    # Export Excel as parquets first
+    export_excel_as_parquet(agency_name, list_of_files)
+
+    # Read in parquet and concatenate together as df to do further filtering
+    raw_samtrans = pd.concat([
+        pd.read_parquet(
+            f"{AGENCY_GCS}{agency_name}/{Path(filename).stem}.parquet",
+        ) for filename in list_of_files
+    ], axis=0, ignore_index=True)
+ 
     raw_samtrans = raw_samtrans[~raw_samtrans["Route"].str.startswith(("Applied filters"), na=False)]
 
     raw_samtrans_agg = (
@@ -67,7 +102,7 @@ def ingest_samtrans(
     )
     
     return raw_samtrans_export
-    
+
 
 if __name__ == "__main__":
    

--- a/scripts/clean_santa_cruz_metro.py
+++ b/scripts/clean_santa_cruz_metro.py
@@ -1,0 +1,103 @@
+"""
+Santa Cruz Metro
+
+1. Combine four files to one dataset
+2. Extract date information from file names
+3. Hard code start date and end date for the FY2025 (2024-07-01 to 2025-06-30)
+4. Format stop name and agg/sum ridership for the same stop. E.g., "Barack Obama Blvd + W San Carlos" and "Barack Obama Blvd + W San Carlos [0901]".
+5. stop id 2594 has two diff stop names: Freedom Blvd (K-Mart) and Freedom Blvd (Vallarta Supermarkets). 
+stop id 1796: "Soquel Ave + Pacheco Ave" and "Soquel Ave + San Juan Ave" stop id 1666: "Ocean + Hubbard " 
+and "Ocean + Washburn Ave" We could make the name consistent (keep the first one), but for now, keep both since stop name may change over time.
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def flatten_columns_scm(columns: list) -> list:
+    """Flatten a multi-index of two header rows into single column names."""
+    
+    new_cols = []
+    for top, bottom in columns:
+        top = str(top).strip() if pd.notna(top) else ""
+        bottom = str(bottom).strip() if pd.notna(bottom) else ""
+        
+        if bottom.startswith("Unnamed"):
+            bottom = ""
+        if bottom and bottom != top:
+            name = f"{top} {bottom}".strip()
+        else:
+            name = top
+            
+        new_cols.append(name)
+    
+    return new_cols
+
+
+def clean_individual_excel(filename: str):
+    """
+    For each individual Excel workbook, grab the rows we need,
+    aggregate boardings and aligtings, add a column to designate the file it came from. 
+    """
+    raw_scm = pd.read_excel(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}", 
+        header=[0,1], engine="openpyxl"
+    )
+    raw_scm.columns = flatten_columns_scm(raw_scm.columns)
+    
+    raw_scm = raw_scm[~raw_scm["Stop Name"].str.startswith(("Total", "Minimum", "Maximum", "Average", "Std. Dev."), na=False)]
+	
+    raw_scm["filename"] = filename
+    raw_scm["Stop Name"] = raw_scm["Stop Name"].str.replace(r"\s*\[.*$", "", regex=True).str.strip()
+	
+    raw_scm_grouped = raw_scm.groupby(
+        by=["Stop Name", "Stop ID", "filename"], 
+        as_index=False, dropna=False
+    ).agg({
+        "Boardings": "sum", 
+        "Alightings": "sum"
+    }).reset_index()
+
+    return raw_scm_grouped
+
+
+def ingest_santa_cruz_metro(
+    agency_name: str = "santa_cruz_metro",
+) -> pd.DataFrame:
+    """
+    """
+    list_of_files = list(RAW_DATA_YAML[agency_name])
+
+    list_of_cleaned_dfs = [clean_individual_excel(one_filename) for one_filename in list_of_files]
+    raw_scm_export = pd.concat(list_of_cleaned_dfs, axis=0, ignore_index=True)
+
+    start_date, end_date = time_utils.get_fiscal_year_range(2025, 7)
+    
+    raw_scm_export = raw_scm_export.assign(
+        start_date = pd.to_datetime(start_date),
+        end_date = pd.to_datetime(end_date),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    )
+
+    raw_scm_export = raw_scm_export.groupby(
+        by=["Stop Name", "Stop ID", "start_date", "end_date"], dropna=False
+    ).agg({
+        "Boardings": "sum", 
+        "Alightings": "sum"
+    }).reset_index()
+
+    return raw_scm_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "santa_cruz_metro"
+    
+    raw_scm_export = ingest_santa_cruz_metro(agency_name)
+    raw_scm_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_sbmtd.py
+++ b/scripts/clean_sbmtd.py
@@ -1,0 +1,71 @@
+"""
+Santa Barbara Metropolitan Transit District
+1. Reformat to long format
+2. Average from monthly to daily
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def process_individual_sheet(
+    filename: str,
+    sheet_name: str
+) -> pd.DataFrame:
+    """
+    """
+    t_df_sbmtd = pd.read_excel(filename, sheet_name=sheet_name, header=2, engine="openpyxl")
+    
+    # drop "Grand Total" col, and "Total" row
+    t_df_sbmtd = t_df_sbmtd.loc[:, ~t_df_sbmtd.columns.str.contains("Grand Total", case=False, na=False)]
+    t_df_sbmtd = t_df_sbmtd[~t_df_sbmtd.iloc[:, 0].astype(str).str.strip().str.lower().eq("total")]
+
+    # identify stop id and stop name cols and month cols
+    id_cols = t_df_sbmtd.columns[:2].tolist()
+    month_cols = t_df_sbmtd.columns[2:].tolist()
+
+    # melt into long format
+    t_df_sbmtd_long = t_df_sbmtd.melt(id_vars=id_cols, var_name="month_str", value_name=sheet_name)
+
+    # get start and end date for each month
+    t_df_sbmtd_long["start_date"] = t_df_sbmtd_long["month_str"].apply(lambda x: x.replace(day=1) if pd.notnull(x) else None)
+    t_df_sbmtd_long["end_date"] = t_df_sbmtd_long["month_str"].apply(lambda x: x.replace(day=1) + pd.tseries.offsets.MonthEnd(1) if pd.notnull(x) else None)
+    
+    t_df_sbmtd_long.columns = t_df_sbmtd_long.columns.str.strip()
+    
+    return t_df_sbmtd_long
+    
+    
+def ingest_sbmtd(
+    agency_name: str = "sbmtd"
+) -> pd.DataFrame:
+    """
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    sheet_names = ["Ridership by Stop_Boardings", "Ridership by Stop_Alightings", "Ridership by Stop_Total Act."]
+    t_dfs = [process_individual_sheet(f"{LOCAL_FOLDER}{agency_name}/{filename}", one_sheet_name) for one_sheet_name in sheet_names]
+
+    # merge all three sheets on stop id, stop name and month str
+    raw_sbmtd = t_dfs[0]
+    for t_df in t_dfs[1:]:
+        raw_sbmtd = pd.merge(raw_sbmtd, t_df, on=["Stop ID", "Stop Name", "month_str", "start_date", "end_date"])
+
+    raw_sbmtd["days_in_month"] = pd.to_datetime(raw_sbmtd["start_date"]).dt.days_in_month
+    raw_sbmtd["avg_boardings"] = 1.0*raw_sbmtd["Ridership by Stop_Boardings"]/raw_sbmtd["days_in_month"]
+    raw_sbmtd["avg_alightings"] = 1.0*raw_sbmtd["Ridership by Stop_Alightings"]/raw_sbmtd["days_in_month"]
+    raw_sbmtd["avg_ridership"] = 1.0*raw_sbmtd["Ridership by Stop_Total Act."]/raw_sbmtd["days_in_month"]
+    raw_sbmtd["day_type"] = "all"
+    raw_sbmtd["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    
+    return raw_sbmtd
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "sbmtd"
+    raw_sbmtd = ingest_sbmtd(agency_name)
+    raw_sbmtd.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+	
+    print(f"exported: {agency_name}")

--- a/scripts/clean_sdmts.py
+++ b/scripts/clean_sdmts.py
@@ -1,0 +1,63 @@
+"""
+San Diego MTS
+
+Agg to stop level. The raw data is avg ridership for each trip-stop.
+Note: Same stop ID can have more than on Stop Sequence in this dataset. In agg, stop sequence is not included.
+
+"""
+import gcsfs
+import pandas as pd
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+def ingest_sdmts(
+    agency_name: str = "sdmts"
+) -> pd.DataFrame:
+    """
+    """
+    list_of_files = list(RAW_DATA_YAML[agency_name][:2])
+    
+    raw_mts = pd.concat([ 
+        pd.read_csv(f"{LOCAL_FOLDER}{agency_name}/{filename}")
+        for filename in list_of_files
+    ], axis=0, ignore_index=True)
+
+    raw_mts.columns = raw_mts.columns.str.strip()
+    raw_mts_export = (
+        raw_mts.groupby(
+            ["Schedule Period", "Day Of Week", "Route", "Route Name", 
+             "Stop ID", "Stop Name", "Direction ID", "Direction Label"], dropna=False)
+        [["Average On", "Average Off"]]
+        .sum()
+        .reset_index()
+    )
+    
+    day_type_map = {
+        "1-Weekday": "Weekday",
+        "2-Saturday": "Saturday",
+        "3-Sunday": "Sunday"
+    }
+    
+    raw_mts_export[["start_date_str", "end_date_str"]] = raw_mts_export["Schedule Period"].str.extract(r'([A-Za-z]+\s*\d{1,2},\s*\d{4})\s*-\s*([A-Za-z]+\s*\d{1,2},\s*\d{4})')
+
+    raw_mts_export = raw_mts_export.assign(
+        day_type = raw_mts_export["Day Of Week"].map(day_type_map),
+        start_date = pd.to_datetime(raw_mts_export["start_date_str"]),
+        end_date = pd.to_datetime(raw_mts_export["end_date_str"]),
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+    ).drop(columns=["start_date_str", "end_date_str"])
+        
+
+    return raw_mts_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "sdmts"
+    
+    raw_mts_export = ingest_sdmts(agency_name)
+    raw_mts_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+	
+    print(f"exported: {agency_name}")

--- a/scripts/clean_sunline.py
+++ b/scripts/clean_sunline.py
@@ -1,0 +1,132 @@
+"""
+SunLine Transit
+Format the data.
+"""
+import gcsfs
+import pandas as pd
+
+import time_utils
+from shared_vars import LOCAL_FOLDER, RAW_GCS, AGENCY_TO_GTFS_NAME_DICT, RAW_DATA_YAML
+
+
+def parse_ridership_columns(ridership_columns: list) -> pd.DataFrame:
+    """
+    """
+    meta = []
+    for top, mid, bottom in ridership_columns:
+        meta.append({
+                    "col": (top, mid, bottom),
+                    "period": str(top).strip(),
+                    "date_range": str(mid).strip(),
+                    "metric": str(bottom).strip()
+        })
+        
+    df_meta = pd.DataFrame(meta)
+    
+    # extract start and end date
+    df_meta[['start_date_str', 'end_date_str']] = df_meta['date_range'].str.extract(
+        r'(\w+\s*\d{1,2},\s*\d{4})\s*to\s*(\w+\s*\d{1,2},\s*\d{4})'
+    )
+    df_meta['start_date'] = pd.to_datetime(df_meta['start_date_str'])
+    df_meta['end_date'] = pd.to_datetime(df_meta['end_date_str'])
+    df_meta['agg_basis'] = df_meta['period'].apply(
+        lambda x: 'fiscal year' if isinstance(x, str) and 'FY' in x else 'season'
+    )
+
+    return df_meta
+
+def make_sunline_df_long(
+    raw_sunline_df: pd.DataFrame,
+    ridership_meta_df: pd.DataFrame,
+    static_cols: list
+) -> pd.DataFrame:
+    # loop over ridership metric columns and build long-format rows
+    long_frames = []
+    
+    for row in ridership_meta_df.itertuples():
+        col = getattr(row, "col")
+        
+        t_df_static = raw_sunline_df[static_cols].assign(
+            metric = getattr(row, "metric"),
+            value = raw_sunline_df[col],
+            period = getattr(row, "period"),
+            start_date = getattr(row, "start_date"),
+            end_date = getattr(row, "end_date"),
+            agg_basis = getattr(row, "agg_basis")
+        )
+        long_frames.append(t_df_static)
+
+    
+    t_df_long = pd.concat(long_frames, ignore_index=True)
+    
+    return t_df_long
+
+def ingest_sunline_transit(
+    agency_name: str = "sunline_transit",
+) -> pd.DataFrame:
+    """
+    Clean up multi-index columns for stop.
+    For ridership, unpack the 3-lines for column names, 
+    add those as columns, and build a long df to export
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+    
+    raw_sunline = pd.read_excel(
+	    f"{LOCAL_FOLDER}{agency_name}/{filename}", header=[0,1,2], 
+        engine="openpyxl", 
+	)
+    static_cols = ["Stop ID", "Stop Name", "Latitude", "Longitude", "Route Serves Stop"]
+    raw_sunline.columns = [
+        static_cols[i] if i < len(static_cols) else raw_sunline.columns[i] 
+        for i in range(len(raw_sunline.columns))
+    ]
+
+    ridership_cols = ["APC Boards", "APC Alights", "Avg. Boards", "Avg. Alights"]
+    ridership_cols_raw = [col for col in raw_sunline.columns if col not in static_cols]
+    df_meta = parse_ridership_columns(ridership_cols_raw)
+    
+    t_df_long = make_sunline_df_long(raw_sunline, df_meta, static_cols)
+    
+    # pivot ridership metrics into columns
+    raw_sunline_export = t_df_long.pivot_table(
+        index=["Stop ID", "Stop Name", "Latitude", "Longitude", 
+               "Route Serves Stop", "period", "start_date", "end_date", "agg_basis"],
+        columns='metric',
+        values='value',
+       aggfunc='first' # when multiple rows have same index+column values, take the first non-null row
+    ).reset_index()
+
+    # all of these have characters that need to be parsed first. then set dtype
+    for col in ["APC Alights", "APC Boards", "Avg. Alights", "Avg. Boards"]:
+        raw_sunline_export[col] = pd.to_numeric(
+                                    raw_sunline_export.apply(
+                                        lambda x: str(x[col]).strip().replace('-', '').replace('nan', ''), 
+                                        axis= 1)
+                                    )
+    
+    raw_sunline_export = raw_sunline_export.assign(
+        day_type = "all",
+        schedule_name = AGENCY_TO_GTFS_NAME_DICT[agency_name],
+    ).astype({
+        # explicitly set dtypes for parquet 
+        "Route Serves Stop": "str", # looks like mixed integer and strings, should be string
+        "APC Alights": "Int64",
+        "APC Boards": "Int64",
+        "Avg. Alights": "float",
+        "Avg. Boards": "float"
+    })
+    
+    return raw_sunline_export
+    
+
+if __name__ == "__main__":
+   
+    agency_name = "sunline_transit"
+    
+    raw_sunline_export = ingest_sunline_transit(agency_name)
+    raw_sunline_export.to_parquet(
+        f"{RAW_GCS}{agency_name}/ridership_round1.parquet",
+        filesystem = gcsfs.GCSFileSystem()
+    )
+
+    print(f"exported: {agency_name}")

--- a/scripts/notes.md
+++ b/scripts/notes.md
@@ -11,6 +11,10 @@
 1. Each individual transit agency's file gets put together (`Preprocess.ipynb`). Schema, number of files, how to put together all differ. --> second round might be more set schema
    * indiv transit agencies will need their data cleaned separately (ingest + clean for each agency)
    * currently saved out as xlsx -> switch to parquets in GCS (`raw`, designate suffix for `_round1`, `_round2` so all inputs from agency across multiple years can share the same folder)
+   * TODOs for 2nd round, possibly for 1st: 
+      - `snakecase` all columns for 2nd round, this would change the subsequent ways columns are called
+      - dtypes need to be set with `.astype()` early on, esp because parquets will store it. some look mixed, int or string `routes can be 1, 2, 3, but also 1A, so it's string`. metadata yaml no longer needed if parquets bring dtypes correctly. 
+      - column names set early on, similar schema across all operators. if snakecased, then renaming happens only once, rather than throughout scripts. dtype would have to work across all operators (cannot be integer if there is 1+ operator with a string). might end up being the same as GTFS dtypes.
    * next step joins with GTFS, and here, it'd be helpful to map the schedule name as a column
 2. There is deeper cleaning on stop_ids and strings to prepare for joining with GTFS.
    * This step can be isolated conceptually, because values get overwritten to use with another data source

--- a/scripts/raw_datasets.yml
+++ b/scripts/raw_datasets.yml
@@ -6,11 +6,11 @@ big_blue_bus:
 caltrain:
 - "Caltrain Average Ridership Estimates - Origin Station Detail (as of August 2025).xlsx"
 - "Caltrain Monthly Ridership Estimates (as of August 2025).xlsx"
-fresno_area_express:
-- "Daily Stop Level Data 9.1.24 - 8.31.25.xlsx"
 culver_citybus:
 - "Ridership by Time Period, Route, and Stop_7_14_25-8_25_25.csv"
 - "Ridership by Trip_7_14_25-8_26_25.csv"
+fresno_area_express:
+- "Daily Stop Level Data 9.1.24 - 8.31.25.xlsx"
 gold_coast_transit:
 - "Longitudinal Stop Ridership Data.xls"
 golden_gate_park_shuttle:

--- a/scripts/raw_datasets.yml
+++ b/scripts/raw_datasets.yml
@@ -6,9 +6,9 @@ big_blue_bus:
 caltrain:
 - "Caltrain Average Ridership Estimates - Origin Station Detail (as of August 2025).xlsx"
 - "Caltrain Monthly Ridership Estimates (as of August 2025).xlsx"
-city_of_fresno:
+fresno_area_express:
 - "Daily Stop Level Data 9.1.24 - 8.31.25.xlsx"
-culver_city_bus:
+culver_citybus:
 - "Ridership by Time Period, Route, and Stop_7_14_25-8_25_25.csv"
 - "Ridership by Trip_7_14_25-8_26_25.csv"
 gold_coast_transit:

--- a/scripts/shared_vars.py
+++ b/scripts/shared_vars.py
@@ -28,6 +28,7 @@ AGENCY_TO_GTFS_NAME_DICT = {
 	"long_beach_transit": "Long Beach Schedule",
 	"octa": "OCTA Schedule",
 	"omnitrans": "OmniTrans Schedule",
+    "riverside_transit": "Riverside Schedule",
 	"sbmtd": "SBMTD Schedule",
 	"sdmts": "San Diego Schedule",
 	"sacrt": "Sacramento Schedule",

--- a/scripts/shared_vars.py
+++ b/scripts/shared_vars.py
@@ -2,7 +2,7 @@ import yaml
 from pathlib import Path
 
 GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/transit-ridership-analytics/"
-LOCAL_FOLDER = "../transit_agency_ridership_raw_datasets2/"
+LOCAL_FOLDER = "../transit_agency_ridership_raw_datasets/"
 AGENCY_GCS = f"{GCS_FILE_PATH}transit_agency_raw/"
 RAW_GCS = f"{GCS_FILE_PATH}raw/"
 INTERMED_GCS = f"{GCS_FILE_PATH}intermediate/"

--- a/scripts/shared_vars.py
+++ b/scripts/shared_vars.py
@@ -21,7 +21,7 @@ AGENCY_TO_GTFS_NAME_DICT = {
 	"fresno_area_express": "Fresno Schedule", # or is it Fresno County Schedule
 	"culver_citybus": "Culver City Schedule",
 	"foothill_transit": "Foothill Schedule",
-	"gold_coast_transit": ,# TODO find entry
+	"gold_coast_transit": "Gold Coast Schedule",
 	"golden_gate_park_shuttle": "Bay Area 511 Golden Gate Park Shuttle Schedule",
 	"golden_gate_transit": "Bay Area 511 Golden Gate Transit Schedule",
 	"long_beach_transit": "Long Beach Schedule",

--- a/scripts/shared_vars.py
+++ b/scripts/shared_vars.py
@@ -1,11 +1,38 @@
+import yaml
+from pathlib import Path
+
 GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/transit-ridership-analytics/"
 AGENCY_GCS = f"{GCS_FILE_PATH}transit_agency_raw/"
 RAW_GCS = f"{GCS_FILE_PATH}raw/"
 INTERMED_GCS = f"{GCS_FILE_PATH}intermediate/"
 PROCESSED_GCS = f"{GCS_FILE_PATH}processed/"
 
+RAW_DATA_YAML_PATH = Path("raw_datasets.yml")
+
+with open(RAW_DATA_YAML) as f:
+    RAW_DATA_YAML = yaml.safe_load(Path(RAW_DATA_YAML_PATH).read_text())
+
 # Map the existing agency names "City of Fresno", "BART" to the schedule_name that is used in warehouse
 # GTFS stop data comes in feeds, which use schedule_name
-AGENCY_TO_GTFS_NAMES_DICT = {
-	
+AGENCY_TO_GTFS_NAME_DICT = {
+    "bart": "Bay Area 511 BART Schedule",
+    "big_blue_bus": "Big Blue Bus Schedule",
+    "caltrain": "Bay Area 511 Caltrain Schedule",
+	"fresno_area_express": "Fresno Schedule", # or is it Fresno County Schedule
+	"culver_citybus": "Culver City Schedule",
+	"foothill_transit": "Foothill Schedule",
+	"gold_coast_transit": ,# TODO find entry
+	"golden_gate_park_shuttle": "Bay Area 511 Golden Gate Park Shuttle Schedule",
+	"golden_gate_transit": "Bay Area 511 Golden Gate Transit Schedule",
+	"long_beach_transit": "Long Beach Schedule",
+	"octa": "OCTA Schedule",
+	"omnitrans": "OmniTrans Schedule",
+	"sbmtd": "SBMTD Schedule",
+	"sdmts": "San Diego Schedule",
+	"sacrt": "Sacramento Schedule",
+	"samtrans": "Bay Area 511 SamTrans Schedule",
+	"santa_cruz_metro": "Santa Cruz Schedule",
+	"sunline_transit": "SunLine Avail Schedule",
+     # while mapping names, should all columns become snakecase?   
 }
+

--- a/scripts/shared_vars.py
+++ b/scripts/shared_vars.py
@@ -2,6 +2,7 @@ import yaml
 from pathlib import Path
 
 GCS_FILE_PATH = "gs://calitp-analytics-data/data-analyses/transit-ridership-analytics/"
+LOCAL_FOLDER = "../transit_agency_ridership_raw_datasets2/"
 AGENCY_GCS = f"{GCS_FILE_PATH}transit_agency_raw/"
 RAW_GCS = f"{GCS_FILE_PATH}raw/"
 INTERMED_GCS = f"{GCS_FILE_PATH}intermediate/"

--- a/scripts/shared_vars.py
+++ b/scripts/shared_vars.py
@@ -9,7 +9,7 @@ PROCESSED_GCS = f"{GCS_FILE_PATH}processed/"
 
 RAW_DATA_YAML_PATH = Path("raw_datasets.yml")
 
-with open(RAW_DATA_YAML) as f:
+with open(RAW_DATA_YAML_PATH) as f:
     RAW_DATA_YAML = yaml.safe_load(Path(RAW_DATA_YAML_PATH).read_text())
 
 # Map the existing agency names "City of Fresno", "BART" to the schedule_name that is used in warehouse

--- a/scripts/time_utils.py
+++ b/scripts/time_utils.py
@@ -31,10 +31,8 @@ def get_day_type(date):
 	holidays = cal.holidays(start='2020-01-01', end='2025-12-31')
     
 	if date in holidays:
-        return "holiday"
-    elif date.weekday() < 5:
-        return "weekday"
-    else:
-        return "weekend"
-
-
+		return "holiday"
+	elif date.weekday() < 5:
+		return "weekday"
+	else:
+		return "weekend"

--- a/scripts/time_utils.py
+++ b/scripts/time_utils.py
@@ -1,0 +1,40 @@
+"""
+Date and time wrangling.
+Working with fiscal years, holidays, etc.
+"""
+import calendar
+import pandas as pd
+from datetime import date, timedelta, datetime
+from pandas.tseries.holiday import USFederalHolidayCalendar
+
+
+def get_fiscal_year_range(fiscal_year: int, start_month: int):
+    # given fiscal year and start month, return the start and end date of the fiscal year
+    
+    start_year = fiscal_year - 1 if start_month != 1 else fiscal_year
+    start_date = date(start_year, start_month, 1)
+    
+    # compute end date
+    if start_month == 1:
+        end_date = date(fiscal_year, 12, 31)
+    else:
+        end_month = (start_month-1)
+        next_month = date(fiscal_year, start_month, 1)
+        end_date = next_month - timedelta(days=1)
+    
+    return start_date.strftime("%Y-%m-%d"), end_date.strftime("%Y-%m-%d")
+        
+
+def get_day_type(date):
+	# get holidays
+	cal = USFederalHolidayCalendar()
+	holidays = cal.holidays(start='2020-01-01', end='2025-12-31')
+    
+	if date in holidays:
+        return "holiday"
+    elif date.weekday() < 5:
+        return "weekday"
+    else:
+        return "weekend"
+
+

--- a/scripts/time_utils.py
+++ b/scripts/time_utils.py
@@ -7,6 +7,9 @@ import pandas as pd
 from datetime import date, timedelta, datetime
 from pandas.tseries.holiday import USFederalHolidayCalendar
 
+# get holidays
+cal = USFederalHolidayCalendar()
+holidays = cal.holidays(start='2020-01-01', end='2025-12-31')
 
 def get_fiscal_year_range(fiscal_year: int, start_month: int):
     # given fiscal year and start month, return the start and end date of the fiscal year
@@ -26,10 +29,7 @@ def get_fiscal_year_range(fiscal_year: int, start_month: int):
         
 
 def get_day_type(date):
-	# get holidays
-	cal = USFederalHolidayCalendar()
-	holidays = cal.holidays(start='2020-01-01', end='2025-12-31')
-    
+
 	if date in holidays:
 		return "holiday"
 	elif date.weekday() < 5:

--- a/scripts/upload_raw_excel_to_gcs.py
+++ b/scripts/upload_raw_excel_to_gcs.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
 	# This is where the datasets are uploaded locally 
 	# Switch for round 2 (this folder will not exist in GitHub after round 1)
-	LOCAL_FOLDER = Path("../transit_agency_ridership_raw_datasets/")
+	LOCAL_FOLDER = Path("../transit_agency_ridership_raw_datasets2/")
 
 	# Loop through each operator and upload the file into its own folder
 	for one_operator_name in list(raw_data_dict.keys()):
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 			gcs_file = f"{AGENCY_GCS}{one_operator_name}/{one_file}"
 			#print(f"{local_file} is uploaded as {gcs_file}")
 			
-			fs.put(local_file, gcs_file)
+			fs.put_file(local_file, gcs_file)
 			
 		print(f"uploaded {one_operator_name}")
 		


### PR DESCRIPTION
* Go through all the data cleaning done in `Pre-process.ipynb` and work it into specific scripts that isolate each transit agency -> easier for 2nd round to figure out what still needs to happen vs not happen
   * Used `_round1.parquet` as suffix to separate 1st round from subsequent rounds of data collection 
   * Light refactoring to organize concepts, esp moving renaming of columns and setting data types for parquets
   * More could be done, outlined in `notes.md` of snakecasing and renaming column names to match `agency_config/*.yml`, because those are the desired column names. Hold off on these for now - would need to double check we are reproducing same results
* Use `Makefile` to show the order of visually inspecting what transit agencies provide, clean and save out parquets, and also check in raw csvs or Excel
* `foothill_transit` and `riverside_transit` are the 2 keys that still need to be added to `raw_datasets.yml` 
* `samtrans` and `riverside_transit` have slightly different workflow, where raw inputs are converted to parquets first. Excel / csvs are so slow for this step. Read parquets in, continue with minimal preprocessing, to get into `[agency_name]_ridership.parquet`
* Add `time_utils` to do some of the shared fiscal year and day_type categorizing. Noticed row-wise operations were a bit slow on `fresno_area_express` and `golden_gate_transit`, moved the calendar out so it's not doing it for each row.
* TODO: add a function where raw files could be downloaded again, maybe do it in `ridership_utils/utils.py`