### PR TITLE
Add foothill transit and update riveride transit scripts

### DIFF
--- a/scripts/clean_foothill.py
+++ b/scripts/clean_foothill.py
@@ -1,0 +1,91 @@
+"""
+Foothill Transit
+Infer column names.
+Aggregate trip-stop data to stop-level.
+"""
+
+import calendar
+
+import gcsfs
+import pandas as pd
+import time_utils
+from shared_vars import AGENCY_TO_GTFS_NAME_DICT, LOCAL_FOLDER, RAW_DATA_YAML, RAW_GCS
+
+
+def ingest_foothill_transit(
+    agency_name: str = "foothill_transit",
+) -> pd.DataFrame:
+    """
+    Import Foothill Transit Excel.
+    Add column names to the raw data since it doesn't come with headers.
+    Aggregate the inferred boardings/aligtings columns to stop, route, direction level from trip-stop level.
+    Each stop may appear multiple times if it serves multiple routes.
+    """
+    filename = RAW_DATA_YAML[agency_name][0]
+
+
+    # import data with inferred column names
+    column_names=["unknown_1", "date", "unknown_2", "block_id", "route_short_name", "unknown_3", "direction", "stop_code", "unknown_4",
+              "unknown_5", "unknown_6", "stop_lat", "stop_lon", "boardings", "alightings", "max_load"]
+    
+    raw_foothill_transit = pd.read_csv(
+        f"{LOCAL_FOLDER}{agency_name}/{filename}",
+        encoding="utf-8",
+        header=None, 
+        names=column_names
+    )
+
+    # aggregate to route-direction-stop level (not sure the level of detail in raw since it doesn't come with header)
+    raw_foothill_transit["date"] = pd.to_datetime(raw_foothill_transit["date"]).dt.floor('D')
+    
+    raw_foothill_transit_export = (
+        raw_foothill_transit.groupby(by=["date", "route_short_name", "direction", "stop_code", "stop_lat", "stop_lon"], as_index=False, dropna=False)
+            .agg(boardings = ("boardings", "sum"), 
+                 alightings = ("alightings", "sum"))
+    )
+
+    raw_foothill_transit_export["start_date"] = raw_foothill_transit_export["date"]
+    raw_foothill_transit_export["end_date"] = raw_foothill_transit_export["date"]
+    raw_foothill_transit_export["day_type"] = raw_foothill_transit_export["date"].apply(time_utils.get_day_type)
+    raw_foothill_transit_export["schedule_name"] = AGENCY_TO_GTFS_NAME_DICT[agency_name]
+
+    return raw_foothill_transit_export
+
+def rename_operator_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Rename columns to a shared schema.
+    Use agency_config/*.yml to see what those names are.
+
+    Create columns that add information about variation across operators
+    - reporting_unit
+    - ridership_measure
+    - geographic grain
+    - daily_ridership_basis
+    """
+    RENAME_COLS_DICT = {
+        "route_short_name": "route_id",
+        "stop_code": "stop_id",
+        "boardings": "avg_boardings",
+        "alightings": "avg_alightings",
+        "lat": "stop_lat",
+        "lon": "stop_lon"
+    }
+
+    df = df.assign(
+        reporting_unit="day",
+        ridership_measure="daily",
+        geography_grain="trip_stop",
+        daily_ridership_basis="reported_daily",
+    ).rename(columns=RENAME_COLS_DICT)
+
+    return df
+
+
+if __name__ == "__main__":
+
+    agency_name = "foothill_transit"
+
+    raw_foothill_transit_export = ingest_foothill_transit(agency_name)
+    raw_foothill_transit_export.to_parquet(f"{RAW_GCS}{agency_name}/ridership_round1.parquet", filesystem=gcsfs.GCSFileSystem())
+
+    print(f"exported: {agency_name}")

--- a/scripts/clean_riverside_transit.py
+++ b/scripts/clean_riverside_transit.py
@@ -59,7 +59,7 @@ def filter_transactions(filename: str) -> pd.DataFrame:
     # these dtypes should match what we'll use for transactions -> stop ridership
     t_raw_df = t_raw_df.astype({"Route": "Int64", "Stop ID": "Int64"})
 
-    t_raw_df["Location"] = pd.to_numeric(t_raw_df["Location"], errors='coerce'i
+    t_raw_df["Location"] = pd.to_numeric(t_raw_df["Location"], errors='coerce')
     t_raw_df['Location'] = t_raw_df['Location'].astype('Int64')
 
     # Convert mixed string formats into datetime dtype (1/1/2025 00:00 an 01/01/2025 00:00:00 will be converted to consistent format)

--- a/scripts/clean_riverside_transit.py
+++ b/scripts/clean_riverside_transit.py
@@ -59,7 +59,7 @@ def filter_transactions(filename: str) -> pd.DataFrame:
     # these dtypes should match what we'll use for transactions -> stop ridership
     t_raw_df = t_raw_df.astype({"Route": "Int64", "Stop ID": "Int64"})
 
-    t_raw_df["Location"] = pd.to_numeric(t_raw_df["Location"], errors='coerce')
+    t_raw_df["Location"] = pd.to_numeric(t_raw_df["Location"], errors='coerce'i
     t_raw_df['Location'] = t_raw_df['Location'].astype('Int64')
 
     # Convert mixed string formats into datetime dtype (1/1/2025 00:00 an 01/01/2025 00:00:00 will be converted to consistent format)
@@ -79,8 +79,6 @@ def ingest_riverside_transit(agency_name: str = "riverside_transit") -> pd.DataF
     records for the corresponding combination.
     """
     list_of_files = list(RAW_DATA_YAML[agency_name])
-    for file in list_of_files:
-        print(file)
 
     filtered_raw_transactions = pd.concat(
         [filter_transactions(f"{LOCAL_FOLDER}{agency_name}/{filename}") for filename in list_of_files],

--- a/scripts/clean_riverside_transit.py
+++ b/scripts/clean_riverside_transit.py
@@ -54,10 +54,16 @@ def filter_transactions(filename: str) -> pd.DataFrame:
     if mask.any():
         cutoff_idx = mask.idxmax()
         t_raw_df = t_raw_df.loc[: cutoff_idx - 1]
-
+    
     # Coerce dtypes here because we're saving out filtered transactions too.
     # these dtypes should match what we'll use for transactions -> stop ridership
-    t_raw_df = t_raw_df.astype({"Route": "int", "Stop ID": "int"})
+    t_raw_df = t_raw_df.astype({"Route": "Int64", "Stop ID": "Int64"})
+
+    t_raw_df["Location"] = pd.to_numeric(t_raw_df["Location"], errors='coerce')
+    t_raw_df['Location'] = t_raw_df['Location'].astype('Int64')
+
+    # Convert mixed string formats into datetime dtype (1/1/2025 00:00 an 01/01/2025 00:00:00 will be converted to consistent format)
+    t_raw_df["Date Time"] = pd.to_datetime(t_raw_df["Date Time"], errors="coerce", format="mixed")
 
     return t_raw_df
 
@@ -73,6 +79,8 @@ def ingest_riverside_transit(agency_name: str = "riverside_transit") -> pd.DataF
     records for the corresponding combination.
     """
     list_of_files = list(RAW_DATA_YAML[agency_name])
+    for file in list_of_files:
+        print(file)
 
     filtered_raw_transactions = pd.concat(
         [filter_transactions(f"{LOCAL_FOLDER}{agency_name}/{filename}") for filename in list_of_files],


### PR DESCRIPTION
This PR
- Added data cleaning script for Foothill Transit.
- Updated script for Riverside Transit. 
   - Riverside Transit was missing data from Sep-Oct in downstream date-based aggregation. This PR added explicit datetime parsing with `format="mixed"` for filtered transaction step (right after data is read in and filtered). The source/raw data use slightly different datetime string formats in `Date Time` column (for example, some include seconds while others do not), which caused some dates to be coerced to `NaT` during later processing. So converting `Date Time` to a consistent datetime dtype at an early stage prevents records from being dropped.
   - Standardized Location to nullable integer type because raw data contain mixed numeric/string values (e.g. `1` and `"1"`).

* This PR is a follow up to #40 